### PR TITLE
クエリ文字列を指定して検索できるように実装

### DIFF
--- a/src/main/java/com/assignment8/nameApi/NameController.java
+++ b/src/main/java/com/assignment8/nameApi/NameController.java
@@ -14,8 +14,9 @@ public class NameController {
     }
 
     @GetMapping("/names")
-    public List<Name> findAll() {
-        return nameMapper.findAll();
+    public List<Name> findByNames(NameSearchRequest request) {
+
+        return nameMapper.findByNameStartingWith(request.getStartsWith(), request.getEndsWith(), request.getContains());
 
     }
 

--- a/src/main/java/com/assignment8/nameApi/NameMapper.java
+++ b/src/main/java/com/assignment8/nameApi/NameMapper.java
@@ -9,4 +9,7 @@ import java.util.List;
 public interface NameMapper {
     @Select("SELECT * FROM names")
     List<Name> findAll();
+
+    @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%') AND name LIKE CONCAT('%', #{suffix})AND name LIKE CONCAT('%', #{contains}, '%')")
+    List<Name> findByNameStartingWith(String prefix, String suffix, String contains);
 }

--- a/src/main/java/com/assignment8/nameApi/NameSearchRequest.java
+++ b/src/main/java/com/assignment8/nameApi/NameSearchRequest.java
@@ -1,0 +1,37 @@
+package com.assignment8.nameApi;
+
+public class NameSearchRequest {
+    private String startsWith;
+    private String endsWith;
+    private String contains;
+
+    public NameSearchRequest(String startsWith, String endsWith, String contains) {
+        this.startsWith = startsWith;
+        this.endsWith = endsWith;
+        this.contains = contains;
+    }
+
+    public String getStartsWith() {
+        return startsWith == null ? "" : startsWith;
+    }
+
+    public void setStartsWith(String startsWith) {
+        this.startsWith = startsWith;
+    }
+
+    public String getEndsWith() {
+        return endsWith == null ? "" : endsWith;
+    }
+
+    public void setEndsWith(String endsWith) {
+        this.endsWith = endsWith;
+    }
+
+    public String getContains() {
+        return contains == null ? "" : contains;
+    }
+
+    public void setContains(String contains) {
+        this.contains = contains;
+    }
+}


### PR DESCRIPTION
 # 概要
Read処理を実装し、テーブルから全件取得するAPIにクエリ文字列を指定して検索するAPIを実装しました。

# 全件取得の動作確認
<img width="650" alt="全件取得スクショ" src="https://github.com/u-1pena/assignment8/assets/137189883/d0c146f0-5404-48c0-985d-3d5b1fc9016c">
# クエリ文字列検索の動作確認
<img width="641" alt="endsWith検索" src="https://github.com/u-1pena/assignment8/assets/137189883/45c57533-2e39-4f8e-b4cb-04a94f21cae1">
<img width="648" alt="endsWith,startsWithの複合検索" src="https://github.com/u-1pena/assignment8/assets/137189883/d7499245-428f-4b79-890d-945a97af2f1b">
